### PR TITLE
Fix literals class for translations

### DIFF
--- a/src/scratchblocks.js
+++ b/src/scratchblocks.js
@@ -1770,7 +1770,7 @@ var scratchblocks = function () {
     if (this.hasArrow) {
       var value = this.menu || this.value;
       this.value = lang.dropdowns[value] || value;
-      this.label = new Label(this.value, ['literal-' + this.shape]);
+      this.label = new Label(this.value, ['sb-literal-' + this.shape]);
     }
   };
 

--- a/src/scratchblocks.js
+++ b/src/scratchblocks.js
@@ -1762,7 +1762,7 @@ var scratchblocks = function () {
     return this.isRound ? "(" + text + ")"
          : this.isSquare ? "[" + text + "]"
          : this.isBoolean ? "<>"
-         : this.isStacK ? "{}"
+         : this.isStack ? "{}"
          : text;
   };
 


### PR DESCRIPTION
I'm fairly certain this is all that needs changing. This will fix the class added to literals post-translation (#172) which should make them the right color.